### PR TITLE
Input URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(TBB REQUIRED)
 
 add_executable(${PROJECT_NAME}
     src/main.cpp
+    src/url/Url.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb)

--- a/src/url/Url.cpp
+++ b/src/url/Url.cpp
@@ -19,7 +19,6 @@ std::vector<std::string> Url::loadFromFile() {
             urls.push_back(url);
     }
 
-    file.close();
     return urls;
 }
 

--- a/src/url/Url.cpp
+++ b/src/url/Url.cpp
@@ -1,0 +1,39 @@
+#include "Url.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+std::vector<std::string> Url::loadFromFile() {
+    std::vector<std::string> urls;
+
+    std::ifstream file("../src/url/urls.txt");
+    if (!file) {
+        std::cerr << "Cannot open file specified\n";
+        return urls;
+    }
+
+    std::string url;
+    while (std::getline(file, url)) {
+        if (!url.empty())
+            urls.push_back(url);
+    }
+
+    file.close();
+    return urls;
+}
+
+std::vector<std::string> Url::loadFromConsole() {
+    std::vector<std::string> urls;
+
+    std::cout << "Enter URLs (one per line, empty line to finish):\n";
+
+    std::string url;
+    while (std::getline(std::cin, url)) {
+        if (url.empty()) {
+            break;
+        }
+        urls.push_back(url);
+    }
+    return urls;
+}

--- a/src/url/Url.h
+++ b/src/url/Url.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Url {
+public:
+    static std::vector<std::string> loadFromFile();
+    static std::vector<std::string> loadFromConsole();
+};

--- a/src/url/urls.txt
+++ b/src/url/urls.txt
@@ -1,0 +1,3 @@
+https://www.youtube.com/watch?v=7YRhm45Drgg&list=RD7YRhm45Drgg&start_radio=1
+https://books.toscrape.com/index.html
+https://github.com/aleksa2105/web-scraper


### PR DESCRIPTION
## Pull Request Overview

This PR implements URL input functionality for a web scraper by adding methods to read URLs from both console input and file sources.

- Added `Url` class with static methods for loading URLs from file and console
- Created a sample URLs file containing test URLs for YouTube, books.toscrape.com, and GitHub
- Updated CMakeLists.txt to include the new Url.cpp source file

| File | Description |
| ---- | ----------- |
| src/url/Url.h | Header file defining the Url class with static methods for URL loading |
| src/url/Url.cpp | Implementation of URL loading methods from file and console input |
| src/url/urls.txt | Sample file containing test URLs for the application |
| CMakeLists.txt | Updated build configuration to include the new Url.cpp source file |





---