### PR TITLE
Parallel Book scraper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,11 @@ find_package(CURL REQUIRED)
 add_executable(${PROJECT_NAME}
     src/main.cpp
     src/url/Url.cpp
+    src/products/Book.cpp
+    src/products/Product.cpp
     src/discovery/PageDiscovery.cpp
     src/fetcher/PageFetcher.cpp
+    src/scraper/BookScraper.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} 

--- a/src/products/Book.h
+++ b/src/products/Book.h
@@ -23,6 +23,7 @@ public:
 
     // Utility Methods
     std::string str() const override;
+    bool isValid() const { return !m_title.empty() && m_price > 0.0; }
 };
 
 using BookList = std::vector<Book>;

--- a/src/products/Product.cpp
+++ b/src/products/Product.cpp
@@ -16,11 +16,11 @@ std::string stockStatusStr(StockStatus status) {
 
 std::string productRatingStr(ProductRating rating) {
     switch (rating) {
-    case ProductRating::one_star: return "⋆";
-    case ProductRating::two_star: return "⋆⋆";
-    case ProductRating::three_star: return "⋆⋆⋆";
-    case ProductRating::four_star: return "⋆⋆⋆⋆";
-    case ProductRating::five_star: return "⋆⋆⋆⋆⋆";
+    case ProductRating::one_star: return "⭐";
+    case ProductRating::two_star: return "⭐⭐";
+    case ProductRating::three_star: return "⭐⭐⭐";
+    case ProductRating::four_star: return "⭐⭐⭐⭐";
+    case ProductRating::five_star: return "⭐⭐⭐⭐⭐";
     default: return "unknown";
     }
 }

--- a/src/scraper/BookScraper.cpp
+++ b/src/scraper/BookScraper.cpp
@@ -1,0 +1,247 @@
+#include "BookScraper.h"
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include <tbb/parallel_for.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/blocked_range.h>
+
+// Static regex patterns for books.toscrape.com
+const std::regex BookScraper::s_titlePattern(R"(<h1>([^<]+)</h1>)");
+const std::regex BookScraper::s_pricePattern(R"(£([0-9]+\.[0-9]{2}))");
+const std::regex BookScraper::s_ratingPattern(R"(star-rating\s+(\w+))");
+const std::regex BookScraper::s_stockPattern(R"(In stock \((\d+) available\)|Out of stock)");
+const std::regex BookScraper::s_descriptionPattern(R"(<div id="product_description"[^>]*>\s*<p>([^<]+)</p>)");
+const std::regex BookScraper::s_upcPattern(R"(<th>UPC</th>\s*<td>([^<]+)</td>)");
+const std::regex BookScraper::s_imagePattern(R"DELIM(<div class="item active">\s*<img src="([^"]+)")DELIM");
+const std::regex BookScraper::s_taxPattern(R"(<th>Tax</th>\s*<td>£([0-9]+\.[0-9]{2})</td>)");
+const std::regex BookScraper::s_reviewsPattern(R"((\d+)\s+review)");
+
+BookList BookScraper::scrapeAllBooks(const PageContentList& pages) {
+    if (pages.empty()) {
+        std::cout << "No pages to scrape" << std::endl;
+        return {};
+    }
+
+    std::cout << "Scraping " << pages.size() << " pages into Book objects..." << std::endl;
+
+    tbb::concurrent_vector<Book> scrapedBooks;
+
+    // Parallel scraping of all pages
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, pages.size()),
+        [&](const tbb::blocked_range<size_t>& range) {
+            for (size_t i = range.begin(); i != range.end(); ++i) {
+                const auto& page = pages[i];
+
+                if (page.success && isValidBookPage(page.html)) {
+                    try {
+                        Book book = scrapeBookFromHtml(page.html, page.url);
+                        if (book.isValid()) {
+                            scrapedBooks.push_back(std::move(book));
+                        }
+                    }
+                    catch (const std::exception& e) {
+                        std::cerr << "Error scraping book from " << page.url
+                            << ": " << e.what() << std::endl;
+                    }
+                }
+
+                // Progress indicator
+                if ((i + 1) % 50 == 0 || i + 1 == pages.size()) {
+                    std::cout << "Scraping progress: " << (i + 1) << "/" << pages.size()
+                        << " pages processed" << std::endl;
+                }
+            }
+        }
+    );
+
+    // Convert to regular vector
+    BookList finalBooks;
+    finalBooks.reserve(scrapedBooks.size());
+    for (const auto& book : scrapedBooks) {
+        finalBooks.push_back(book);
+    }
+
+    std::cout << "Scraping completed: " << finalBooks.size() << " valid books extracted" << std::endl;
+    return finalBooks;
+}
+
+Book BookScraper::scrapeBookFromHtml(const std::string& html, const Url& bookUrl) {
+    // Extract book informations
+    const std::string title = extractTitle(html);
+    const double      price = extractPrice(html);
+    const StockStatus stockStatus = extractStockStatus(html);
+    const ProductRating rating = extractRating(html);
+    const std::string description = extractDescription(html);
+    const std::string upc = extractUpc(html);
+    const double      tax = extractTax(html);
+    const int         stockQuantity = extractStockQuantity(html);
+    const int         numReviews = extractNumReviews(html);
+    const Url         imageUrl = extractImageUrl(html, bookUrl);
+
+    Book book(title, price, stockStatus,
+        rating, description, upc,
+        tax, stockQuantity, numReviews,
+        imageUrl, bookUrl
+    );
+
+    return book;
+}
+
+
+std::string BookScraper::extractTitle(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_titlePattern)) {
+        return cleanText(match[1].str());
+    }
+    return "";
+}
+
+double BookScraper::extractPrice(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_pricePattern)) {
+        return parsePrice(match[1].str());
+    }
+    return 0.0;
+}
+
+ProductRating BookScraper::extractRating(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_ratingPattern)) {
+        return parseRatingFromClass(match[1].str());
+    }
+    return ProductRating::unknown;
+}
+
+StockStatus BookScraper::extractStockStatus(const std::string& html) {
+    if (html.find("In stock") != std::string::npos) {
+        return StockStatus::in_stock;
+    }
+    else if (html.find("Out of stock") != std::string::npos) {
+        return StockStatus::out_of_stock;
+    }
+    return StockStatus::unknown;
+}
+
+int BookScraper::extractStockQuantity(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_stockPattern)) {
+        if (match.size() > 1 && !match[1].str().empty()) {
+            return parseStockQuantity(match[1].str());
+        }
+    }
+    return 0;
+}
+
+std::string BookScraper::extractDescription(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_descriptionPattern)) {
+        return cleanText(match[1].str());
+    }
+    return "";
+}
+
+std::string BookScraper::extractUpc(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_upcPattern)) {
+        return cleanText(match[1].str());
+    }
+    return "";
+}
+
+double BookScraper::extractTax(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_taxPattern)) {
+        return parseTax(match[1].str());
+    }
+    return 0.0;
+}
+
+int BookScraper::extractNumReviews(const std::string& html) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_reviewsPattern)) {
+        try {
+            return std::stoi(match[1].str());
+        }
+        catch (const std::exception&) {
+            return 0;
+        }
+    }
+    return 0; // Default 0 if no reviews
+}
+
+Url BookScraper::extractImageUrl(const std::string& html, const Url& baseUrl) {
+    std::smatch match;
+    if (std::regex_search(html, match, s_imagePattern)) {
+        std::string relativeUrl = match[1].str();
+        return baseUrl.makeAbsolute(relativeUrl);
+    }
+    return Url();
+}
+
+std::string BookScraper::cleanText(const std::string& text) {
+    std::string cleaned = text;
+
+    // Remove leading/trailing whitespace
+    cleaned.erase(cleaned.begin(), std::find_if(cleaned.begin(), cleaned.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }));
+    cleaned.erase(std::find_if(cleaned.rbegin(), cleaned.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }).base(), cleaned.end());
+
+    // Replace multiple spaces with single space
+    std::regex multiSpace(R"(\s+)");
+    cleaned = std::regex_replace(cleaned, multiSpace, " ");
+
+    return cleaned;
+}
+
+double BookScraper::parsePrice(const std::string& priceText) {
+    try {
+        return std::stod(priceText);
+    }
+    catch (const std::exception&) {
+        return 0.0;
+    }
+}
+
+ProductRating BookScraper::parseRatingFromClass(const std::string& ratingClass) {
+    std::string lowerClass = ratingClass;
+    std::transform(lowerClass.begin(), lowerClass.end(), lowerClass.begin(), ::tolower);
+
+    if (lowerClass == "one") return ProductRating::one_star;
+    if (lowerClass == "two") return ProductRating::two_star;
+    if (lowerClass == "three") return ProductRating::three_star;
+    if (lowerClass == "four") return ProductRating::four_star;
+    if (lowerClass == "five") return ProductRating::five_star;
+
+    return ProductRating::unknown;
+}
+
+int BookScraper::parseStockQuantity(const std::string& stockText) {
+    try {
+        return std::stoi(stockText);
+    }
+    catch (const std::exception&) {
+        return 0;
+    }
+}
+
+double BookScraper::parseTax(const std::string& taxText) {
+    try {
+        return std::stod(taxText);
+    }
+    catch (const std::exception&) {
+        return 0.0; // Fallback to 0.0 if parsing fails
+    }
+}
+
+bool BookScraper::isValidBookPage(const std::string& html) {
+    // Check for characteristic book page elements
+    return html.find("<h1>") != std::string::npos &&         // Title
+        html.find("star-rating") != std::string::npos &&     // Rating
+        html.find("£") != std::string::npos &&               // Price
+        html.find("availability") != std::string::npos;      // Stock info
+}

--- a/src/scraper/BookScraper.h
+++ b/src/scraper/BookScraper.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "../products/Book.h"
+#include "../fetcher/PageFetcher.h"
+#include <vector>
+#include <string>
+#include <regex>
+
+using BookList = std::vector<Book>;
+
+class BookScraper {
+public:
+
+    /**
+     * Scrapes all books from a list of fetched pages.
+     *
+     * @param pages List of PageContent objects containing catalog or book pages
+     * @return List of all extracted Book objects
+     */
+    static BookList scrapeAllBooks(const PageContentList& pages);
+
+    /**
+     * Scrapes a single book from its HTML content.
+     *
+     * @param html HTML content of the book page
+     * @param bookUrl URL of the book page
+     * @return Book object populated with extracted data
+     */
+    static Book scrapeBookFromHtml(const std::string& html, const Url& bookUrl);
+
+private:
+
+    // Helper methods for parsing specific parts of HTML
+
+    static std::string extractTitle(const std::string& html);
+
+    static double extractPrice(const std::string& html);
+
+    static ProductRating extractRating(const std::string& html);
+
+    static StockStatus extractStockStatus(const std::string& html);
+
+    static int extractStockQuantity(const std::string& html);
+
+    static std::string extractDescription(const std::string& html);
+
+    static std::string extractUpc(const std::string& html);
+
+    static double extractTax(const std::string& html);
+
+    static int extractNumReviews(const std::string& html);
+
+    static Url extractImageUrl(const std::string& html, const Url& baseUrl);
+
+    // Utility methods
+
+    static std::string cleanText(const std::string& text);
+
+    static double parsePrice(const std::string& priceText);
+
+    static ProductRating parseRatingFromClass(const std::string& ratingClass);
+
+    static int parseStockQuantity(const std::string& stockText);
+
+    static double parseTax(const std::string& taxText);
+
+    static bool isValidBookPage(const std::string& html);
+
+    // Regex patterns for books.toscrape.com
+    static const std::regex s_titlePattern;
+    static const std::regex s_pricePattern;
+    static const std::regex s_ratingPattern;
+    static const std::regex s_stockPattern;
+    static const std::regex s_descriptionPattern;
+    static const std::regex s_upcPattern;
+    static const std::regex s_imagePattern;
+    static const std::regex s_taxPattern;
+    static const std::regex s_reviewsPattern;
+};


### PR DESCRIPTION
This pull request introduces a new `BookScraper` component for extracting book information from HTML pages, improves the product rating display, and makes minor enhancements to the `Book` class. The main focus is on enabling robust, parallelized scraping of book data from a collection of fetched web pages.

**Book scraping infrastructure:**

* Added new `BookScraper` class (`src/scraper/BookScraper.h`, `src/scraper/BookScraper.cpp`) to extract book data from HTML using regex, with support for parallel processing via Intel TBB. This includes helper methods for parsing titles, prices, ratings, stock status, descriptions, UPCs, tax, review counts, and image URLs, as well as utility functions for cleaning and validating data. [[1]](diffhunk://#diff-28489ec9bf39b81b412f52cf7ea315e1002e06cbd3e3af22d1b06106f0454adeR1-R247) [[2]](diffhunk://#diff-0b34f15191562f51835843ef39ad0f1eb26f7096125d941e237e56e4a1412561R1-R79)
* Updated `CMakeLists.txt` to include new source files for `BookScraper`, `Book`, and `Product` in the build.

**Product and rating improvements:**

* Changed the product rating string representation from Unicode stars (⋆) to emoji stars (⭐) for better clarity and consistency. (`src/products/Product.cpp`)
* Added a new `isValid()` method to the `Book` class to ensure only books with a title and a positive price are considered valid. (`src/products/Book.h`)